### PR TITLE
Removing X-D2L-App-Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 
 ```js
 var request = require('superagent');
-var auth = require('superagent-d2l-session-auth')('MyAppName');
+var auth = require('superagent-d2l-session-auth');
 
 request
     .get('/d2l/api/lp/1.5/users/whoami')

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
-module.exports = function(appId) {
-    return function(request) {
-        request.set('X-Csrf-Token', localStorage['XSRF.Token']);
-        request.set('X-D2L-App-Id', appId);
-        return request;
-    };
+module.exports = function(req) {
+	req.set('X-Csrf-Token', localStorage['XSRF.Token']);
+	req.set('X-D2L-App-Id', 'deprecated');
+	return req;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-d2l-session-auth",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A superagent plugin that adds D2L auth headers",
   "main": "index.js",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,16 +1,15 @@
 var nock = require('nock'),
 	request = require('superagent');
 
-var APP_ID = 'some-app-id';
 var CSRF_TOKEN = 'some-token';
 global.localStorage = { 'XSRF.Token': CSRF_TOKEN };
 
-var valence = require('../')(APP_ID);
+var valence = require('../');
 
 describe('superagent-valence', function() {
-	it('adds app id', function() {
+	it('adds app id (legacy)', function() {
 		var endpoint = nock('http://localhost')
-			.matchHeader('X-D2L-App-Id', APP_ID)
+			.matchHeader('X-D2L-App-Id', 'deprecated')
 			.matchHeader('X-Csrf-Token', /.*/)
 			.get('/url')
 			.reply(200);


### PR DESCRIPTION
We removed this from the OAuth2 branch of LP, and will be shortly removing it from the main branch. We'll keep sending the header internally so that there is no breakage for users. This is a breaking API change for the library but we are pre-1.0.0. I intend to get us to a "1.0.0" stage very shortly though (there are few other pull requests in the pipeline.)

Some rational for why we removed it
-------------------------------------------------

While it could conceivably serve a purpose for first-party front-ends, its an additional inconsistency with OAuth2 and in practice we found it annoying to specify. It's also dubious that API calls can be attributed to a particular app (via the way we have now) once we start making JS libraries that internally call APIs themselves, mixing "partial views" (the client-side equivalent) etc. There is also the Referer header which could be argued gives better (more likely honest) diagnostics than this...

and at the end of the day, we'll be in the same spot as every other controller action - not knowing who called us or why.