### PR TITLE
Origin safety

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,16 @@
 'use strict';
 
 module.exports = function(req) {
+	// This plugin only works for relative URLs. Sending XSRF tokens to foreign
+	// origins would be bad. This plugin is a no-op in those cases.
+	if (req.url[0] != '/') {
+		console.log(
+			'Warning: using superagent-d2l-session-auth for non-relative URLs will ' +
+			'fall back to vanilla superagent. Either use a relative URL (if possible)' +
+			' or don\'t use this plugin for cross-origin requests.');
+		return req;
+	}
+
 	req.set('X-Csrf-Token', localStorage['XSRF.Token']);
 	req.set('X-D2L-App-Id', 'deprecated');
 	return req;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-d2l-session-auth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A superagent plugin that adds D2L auth headers",
   "main": "index.js",
   "repository": {
@@ -19,6 +19,7 @@
     "jshint": "^2.5.11",
     "mocha": "^2.0.1",
     "nock": "^0.51.0",
+    "should": "^5.0.1",
     "superagent": "^0.21.0"
   },
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 var nock = require('nock'),
+	should = require('should'),
 	request = require('superagent');
 
 var CSRF_TOKEN = 'some-token';
@@ -14,24 +15,30 @@ describe('superagent-valence', function() {
 			.get('/url')
 			.reply(200);
 
-		request.get('http://localhost/url')
+		request.get('/url')
 			.use(valence)
 			.end(function() {});
 
 		endpoint.done();
 	});
 
-	it('adds csrf token', function() {
+	it('adds csrf token for relative URLs', function() {
 		var endpoint = nock('http://localhost')
 			.matchHeader('X-D2L-App-Id', /.*/)
 			.matchHeader('X-Csrf-Token', CSRF_TOKEN)
 			.get('/url')
 			.reply(200);
 
-		request.get('http://localhost/url')
+		request.get('/url')
 			.use(valence)
 			.end(function() {});
 
 		endpoint.done();
+	});
+
+	it('does not add csrf token for non-relative URLs', function() {
+		var req = request.get('http://localhost/url').use(valence);
+
+		should.not.exist(req.header['X-Csrf-Token']);
 	});
 });


### PR DESCRIPTION
**Warning**: wait until #13 is merged - this PR depends on it (the diff will get smaller after that one is merged)

This closes #11 

An alternative strategy would be to allow absolute URLs but compare against `window.location`... but I hate it when people do that.

I thought it would be more pleasant to be kind when people mess up - returning instead of throwing an error. I'm not sure if that's best, though.