### PR TITLE
Add refreshcookie preflight

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function processRefreshResponse(cb) { return function(res) {
 	}
 
 	var directives = cacheControl.split(',');
-	for (var i = 0; i < directives.length; i++) {
+	var len = directives.length;
+	for (var i = 0; i < len; i++) {
 		if (directives[i].indexOf('max-age') == -1) {
 			continue;
 		}

--- a/index.js
+++ b/index.js
@@ -50,17 +50,19 @@ function refreshCookie(cb) {
 	});
 }
 
-function preflight(req, oldEnd) { return function(cb) {
-	if (now() < global.D2LAccessTokenExpiresAt) {
-		req.end = oldEnd;
-		return req.end(cb);
-	}
+function preflight(req, oldEnd) {
+	return function(cb) {
+		if (now() < global.D2LAccessTokenExpiresAt) {
+			req.end = oldEnd;
+			return req.end(cb);
+		}
 
-	refreshCookie(function() {
-		req.end = oldEnd;
-		return req.end(cb);
-	});
-};}
+		refreshCookie(function() {
+			req.end = oldEnd;
+			return req.end(cb);
+		});
+	};
+}
 
 module.exports = function(req) {
 	// This plugin only works for relative URLs. Sending XSRF tokens to foreign

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function addHeaders(req) {
 	req.set('X-D2L-App-Id', 'deprecated');
 }
 
-function processRefreshResponse(cb) { return function(res) {
+function processRefreshResponse(res, cb) {
 	if (!res.ok) {
 		return cb(false);
 	}
@@ -36,7 +36,7 @@ function processRefreshResponse(cb) { return function(res) {
 	}
 
 	return cb(true);
-};}
+}
 
 function refreshCookie(cb) {
 	var req = superagent
@@ -44,7 +44,9 @@ function refreshCookie(cb) {
 
 	addHeaders(req);
 
-	req.end(processRefreshResponse(cb));
+	req.end(function (res) {
+		processRefreshResponse(res, cb);
+	});
 }
 
 function preflight(req, oldEnd) { return function(cb) {

--- a/index.js
+++ b/index.js
@@ -15,12 +15,13 @@ function addHeaders(req) {
 
 function processRefreshResponse(res, cb) {
 	if (!res.ok) {
-		return cb(false);
+		// In the future we should log an error
+		return cb();
 	}
 
 	var cacheControl = res.headers['cache-control'];
 	if (!cacheControl) {
-		return cb(true);
+		return cb();
 	}
 
 	var directives = cacheControl.split(',');
@@ -35,7 +36,7 @@ function processRefreshResponse(res, cb) {
 		break;
 	}
 
-	return cb(true);
+	return cb();
 }
 
 function refreshCookie(cb) {
@@ -55,11 +56,7 @@ function preflight(req, oldEnd) { return function(cb) {
 		return req.end(cb);
 	}
 
-	refreshCookie(function(success) {
-		if (!success) {
-			return req.abort();
-		}
-
+	refreshCookie(function() {
 		req.end = oldEnd;
 		return req.end(cb);
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-d2l-session-auth",
-  "version": "0.1.1",
+  "version": "0.9.0",
   "description": "A superagent plugin that adds D2L auth headers",
   "main": "index.js",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -134,26 +134,27 @@ describe('superagent-valence', function() {
 			});
 	});
 
-	it('blocks request on preflight failure', function(done) {
+	it('doesn\'t block request on preflight failure', function(done) {
 		this.timeout(20);
 		global.D2LAccessTokenExpiresAt = 0;
 
 		var endpoint = nock('http://localhost')
 			.post('/d2l/lp/auth/oauth2/refreshcookie')
-			.reply(404);
+			.reply(404)
+			.get('/api')
+			.reply(200);
 
 		request
 			.get('/api')
 			.use(valence)
 			.end(function() {
-				(true).should.be.false('unreachable code');
+				endpoint.done();
+
+				global.D2LAccessTokenExpiresAt
+					.should.equal(0);
+
 				done();
 			});
-
-		endpoint.done();
-
-		global.D2LAccessTokenExpiresAt
-			.should.equal(0);
 
 		setTimeout(function() { done(); }, 10);
 	});

--- a/test/index.js
+++ b/test/index.js
@@ -2,20 +2,32 @@ var nock = require('nock'),
 	should = require('should'),
 	request = require('superagent');
 
-var CSRF_TOKEN = 'some-token';
-global.localStorage = { 'XSRF.Token': CSRF_TOKEN };
+nock.disableNetConnect();
+
+var XSRF_TOKEN = 'some-token';
+global.localStorage = { 'XSRF.Token': XSRF_TOKEN };
 
 var valence = require('../');
 
+function now() {
+	return Date.now()/1000 | 0;
+}
+
+function theFuture() {
+	return 1000 + now();
+}
+
 describe('superagent-valence', function() {
 	it('adds app id (legacy)', function() {
+		global.D2LAccessTokenExpiresAt = theFuture();
+
 		var endpoint = nock('http://localhost')
 			.matchHeader('X-D2L-App-Id', 'deprecated')
-			.matchHeader('X-Csrf-Token', /.*/)
-			.get('/url')
+			.get('/api')
 			.reply(200);
 
-		request.get('/url')
+		request
+			.get('/api')
 			.use(valence)
 			.end(function() {});
 
@@ -23,22 +35,126 @@ describe('superagent-valence', function() {
 	});
 
 	it('adds csrf token for relative URLs', function() {
+		global.D2LAccessTokenExpiresAt = theFuture();
+
 		var endpoint = nock('http://localhost')
-			.matchHeader('X-D2L-App-Id', /.*/)
-			.matchHeader('X-Csrf-Token', CSRF_TOKEN)
-			.get('/url')
+			.matchHeader('X-Csrf-Token', XSRF_TOKEN)
+			.get('/api')
 			.reply(200);
 
-		request.get('/url')
+		request
+			.get('/api')
 			.use(valence)
 			.end(function() {});
 
 		endpoint.done();
 	});
 
-	it('does not add csrf token for non-relative URLs', function() {
-		var req = request.get('http://localhost/url').use(valence);
+	it('does not add xsrf token for non-relative URLs', function() {
+		var req = request.get('http://localhost/api').use(valence);
 
 		should.not.exist(req.header['X-Csrf-Token']);
+		req.end.should.equal(Object.getPrototypeOf(req).end); // no funny business
+	});
+
+	it('sends refreshcookie preflight on boot', function(done) {
+		global.D2LAccessTokenExpiresAt = 0;
+
+		var endpoint = nock('http://localhost')
+			.post('/d2l/lp/auth/oauth2/refreshcookie')
+			.matchHeader('X-Csrf-Token', XSRF_TOKEN)
+			.reply(204)
+			.get('/api')
+			.matchHeader('X-Csrf-Token', XSRF_TOKEN)
+			.reply(200);
+
+		request
+			.get('/api')
+			.use(valence)
+			.end(function() {
+				endpoint.done();
+
+				global.D2LAccessTokenExpiresAt
+					.should.equal(0); // no cache-control --> can't set an expiry
+
+				done();
+			});
+
+	});
+
+	it('handles basic cache-control header', function(done) {
+		global.D2LAccessTokenExpiresAt = 0;
+
+		var maxLength = 10;
+
+		var endpoint = nock('http://localhost')
+			.post('/d2l/lp/auth/oauth2/refreshcookie')
+			.reply(204, '', {
+				'Cache-Control': 'max-age=' + maxLength
+			})
+			.get('/api')
+			.reply(200);
+
+		request
+			.get('/api')
+			.use(valence)
+			.end(function() {
+				endpoint.done();
+
+				global.D2LAccessTokenExpiresAt
+					.should.be.within(now() - maxLength, now() + maxLength);
+
+				done();
+			});
+	});
+
+	it('handles complicated cache-control header', function(done) {
+		global.D2LAccessTokenExpiresAt = 0;
+
+		var maxLength = 100;
+
+		var endpoint = nock('http://localhost')
+			.post('/d2l/lp/auth/oauth2/refreshcookie')
+			.reply(204, '', {
+				'Cache-Control': 'private , max-age   = ' + maxLength
+			})
+			.get('/api')
+			.reply(200);
+
+		request
+			.get('/api')
+			.use(valence)
+			.end(function() {
+				endpoint.done();
+
+				global.D2LAccessTokenExpiresAt
+					.should.be.within(now() - maxLength, now() + maxLength);
+
+				done();
+			});
+	});
+
+	it('blocks request on preflight failure', function(done) {
+		this.timeout(20);
+		global.D2LAccessTokenExpiresAt = 0;
+
+		var endpoint = nock('http://localhost')
+			.post('/d2l/lp/auth/oauth2/refreshcookie')
+			.reply(404);
+
+		request
+			.get('/api')
+			.use(valence)
+			.end(function() {
+				(true).should.be.false('unreachable code');
+				done();
+			});
+
+		endpoint.done();
+
+		global.D2LAccessTokenExpiresAt
+			.should.equal(0);
+
+		setTimeout(function() { done(); }, 10);
 	});
 });


### PR DESCRIPTION
Ok, this is obviously a big change. This should be "non-breaking" to consumers of this plugin: if anyone can think up scenarios which are not totally contrived but where client JS code would notice we should discuss it.

Why this:
We are adding a new cookie which contains an access token that has a finite lifespan. To keep that token fresh the browser will send a custom pre-flight before API calls that will use your session (no hard expiry) cookie (d2l(Secure)SessionVal) to authenticate you and (re)provision you an access token. The service handling that route will set a Cache-Control to communicate when the client must do a new pre-flight (the max-age will match that of the cookie, and will be "well before" the token actually expires so that we can support "proxy" auth scenarios - come by my desk and ask.)

This was designed so that there would be no ambiguity over whether an API call could fail due to an expired access token, while at the same time hiding this logic from clients. The downsides to this approach is it is nice piece of implementation-detail that could be hidden from clients - people who want to use Angular's `$http` for example are going to have to re-solve this. If you want to discuss how we could make services do this lets discuss it not on Github ;)

The browser should avoid doing the pre-flight when possible.

About versioning: I've bumped this to 0.9.0 arbitrarily (0.10.0 comes next.) Once we have a suitable solution for #15 I'd like to switch this to 1.0.0.

TODO: I need to test this in a free-range app with our feature toggle turned on.