### PR TITLE
upgrading to superagent 1.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ function addHeaders(req) {
 	req.set('X-D2L-App-Id', 'deprecated');
 }
 
-function processRefreshResponse(res, cb) {
-	if (!res.ok) {
+function processRefreshResponse(err, res, cb) {
+	if (err || !res.ok) {
 		// In the future we should log an error
 		return cb();
 	}
@@ -45,8 +45,8 @@ function refreshCookie(cb) {
 
 	addHeaders(req);
 
-	req.end(function (res) {
-		processRefreshResponse(res, cb);
+	req.end(function(err, res) {
+		processRefreshResponse(err, res, cb);
 	});
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "^2.0.1",
     "nock": "^0.51.0",
     "should": "^5.0.1",
-    "superagent": "^0.21.0"
+    "superagent": "^1.2.0"
   },
   "scripts": {
     "pretest": "jshint index.js test",


### PR DESCRIPTION
@j3parker: the major change was that 1.2.0 takes both "err" and "res" params in the "end" callback.