### PR TITLE
make sure the request is always returned from the "end" method

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,15 +52,15 @@ function refreshCookie(cb) {
 
 function preflight(req, oldEnd) {
 	return function(cb) {
-		if (now() < global.D2LAccessTokenExpiresAt) {
+		function finish() {
 			req.end = oldEnd;
 			return req.end(cb);
 		}
-
-		refreshCookie(function() {
-			req.end = oldEnd;
-			return req.end(cb);
-		});
+		if(now() < global.D2LAccessTokenExpiresAt) {
+			return finish();
+		}
+		refreshCookie(finish);
+		return this;
 	};
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -158,4 +158,23 @@ describe('superagent-valence', function() {
 
 		setTimeout(function() { done(); }, 10);
 	});
+
+	it('should return something from "end" when not expired', function() {
+		global.D2LAccessTokenExpiresAt = theFuture();
+		var req = request
+			.get('/api')
+			.use(valence)
+			.end(function() {});
+		should.exist(req);
+	});
+
+	it('should return something from "end" when expired', function() {
+		global.D2LAccessTokenExpiresAt = 0;
+		var req = request
+			.get('/api')
+			.use(valence)
+			.end(function() {});
+		should.exist(req);
+	});
+
 });


### PR DESCRIPTION
@j3parker: small fix so that using this plugin doesn't squash the return value from "end"