### PR TITLE
superagent-as-param

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Usage
 -----
 
 ```js
-var request = require('superagent');
-var auth = require('superagent-d2l-session-auth');
+var request = require('superagent'),
+    auth = require('superagent-d2l-session-auth')(request);
 
 request
     .get('/d2l/api/lp/1.5/users/whoami')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-d2l-session-auth",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A superagent plugin that adds D2L auth headers",
   "main": "index.js",
   "repository": {
@@ -9,7 +9,9 @@
   },
   "keywords": [
     "d2l",
-    "free-range"
+    "free-range",
+    "frau",
+    "superagent"
   ],
   "author": "D2L Corporation",
   "license": "Apache 2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ nock.disableNetConnect();
 var XSRF_TOKEN = 'some-token';
 global.localStorage = { 'XSRF.Token': XSRF_TOKEN };
 
-var valence = require('../');
+var valence = require('../')(request);
 
 function now() {
 	return Date.now()/1000 | 0;


### PR DESCRIPTION
Refactoring to not `require()` its own version of superagent, which might differ from the consumer and potentially bloat browserified modules. Instead, taking superagent as an initial parameter. fixes #22.