### PR TITLE
Handle 404s on the refreshcookie preflight more gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-d2l-session-auth",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A superagent plugin that adds D2L auth headers",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This is per-tab. 404 should only happen prior to OAuth2 and while a tab could exist across a release it wouldn't be trying to call any APIs exclusively auth'd with OAuth2. The OAuth2 cookie is not required by the core LMS for its APIs.

This closes #21 