### PR TITLE
Make Superagent a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 
 ```js
 var request = require('superagent'),
-    auth = require('superagent-d2l-session-auth')(request);
+    auth = require('superagent-d2l-session-auth');
 
 request
     .get('/d2l/api/lp/1.5/users/whoami')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-d2l-session-auth",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A superagent plugin that adds D2L auth headers",
   "main": "index.js",
   "repository": {
@@ -15,6 +15,9 @@
   ],
   "author": "D2L Corporation",
   "license": "Apache 2.0",
+  "peerDependencies": {
+    "superagent": "^1.2.0"
+  },
   "devDependencies": {
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.5",

--- a/test/index.js
+++ b/test/index.js
@@ -7,8 +7,7 @@ nock.disableNetConnect();
 var XSRF_TOKEN = 'some-token';
 global.localStorage = { 'XSRF.Token': XSRF_TOKEN };
 
-var authLib = require('../');
-var auth = authLib(request);
+var auth = require('../');
 
 function now() {
 	return Date.now()/1000 | 0;
@@ -20,12 +19,12 @@ function theFuture() {
 
 describe('superagent-auth', function() {
 	beforeEach(function() {
-		authLib._enableOAuth2();
-		authLib._setAccessTokenExpiry(0);
+		auth._enableOAuth2();
+		auth._setAccessTokenExpiry(0);
 	});
 
 	it('adds app id (legacy)', function() {
-		authLib._setAccessTokenExpiry(theFuture());
+		auth._setAccessTokenExpiry(theFuture());
 
 		var endpoint = nock('http://localhost')
 			.matchHeader('X-D2L-App-Id', 'deprecated')
@@ -41,7 +40,7 @@ describe('superagent-auth', function() {
 	});
 
 	it('adds csrf token for relative URLs', function() {
-		authLib._setAccessTokenExpiry(theFuture());
+		auth._setAccessTokenExpiry(theFuture());
 
 		var endpoint = nock('http://localhost')
 			.matchHeader('X-Csrf-Token', XSRF_TOKEN)
@@ -78,7 +77,7 @@ describe('superagent-auth', function() {
 			.end(function() {
 				endpoint.done();
 
-				authLib._accessTokenExpiry()
+				auth._accessTokenExpiry()
 					.should.equal(0); // no cache-control --> can't set an expiry
 
 				done();
@@ -99,7 +98,7 @@ describe('superagent-auth', function() {
 			.end(function() {
 				endpoint.done();
 
-				authLib._isOAuth2Enabled()
+				auth._isOAuth2Enabled()
 					.should.be.exactly(false);
 
 				done();
@@ -107,7 +106,7 @@ describe('superagent-auth', function() {
 	});
 
 	it('doesnt call refreshcookie if oauth2 is disabled', function(done) {
-		authLib._disableOAuth2();
+		auth._disableOAuth2();
 
 		var endpoint = nock('http://localhost')
 			.get('/api')
@@ -119,7 +118,7 @@ describe('superagent-auth', function() {
 			.end(function() {
 				endpoint.done();
 
-				authLib._isOAuth2Enabled()
+				auth._isOAuth2Enabled()
 					.should.be.exactly(false);
 
 				done();
@@ -143,7 +142,7 @@ describe('superagent-auth', function() {
 			.end(function() {
 				endpoint.done();
 
-				authLib._accessTokenExpiry()
+				auth._accessTokenExpiry()
 					.should.be.within(now() - maxLength, now() + maxLength);
 
 				done();
@@ -167,7 +166,7 @@ describe('superagent-auth', function() {
 			.end(function() {
 				endpoint.done();
 
-				authLib._accessTokenExpiry()
+				auth._accessTokenExpiry()
 					.should.be.within(now() - maxLength, now() + maxLength);
 
 				done();
@@ -187,7 +186,7 @@ describe('superagent-auth', function() {
 			.end(function() {
 				endpoint.done();
 
-				authLib._accessTokenExpiry()
+				auth._accessTokenExpiry()
 					.should.equal(0);
 
 				done();


### PR DESCRIPTION
Moves the superagent dependency into peer dependencies so that it can be guaranteed to exist if superagent-d2l-session-auth is being required. Also ties the versioning of the two together so it can be guaranteed that the version of superagent being worked with is known to work.

From my testing, this will work as long as superagent and superagent-d2l-session-auth are in the same category in the package.json dependencies. i.e. They're both in `dependencies` or `devDependencies`. I didn't test when they are in different categories as that wouldn't make much sense anyways.

Does not cause `superagent` to be included in compiled `app.js` if it is still defined as an external dependency with browserify.