### PR TITLE
Not sending XSRF token for non-relative URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ function now() {
 }
 
 function addHeaders(req) {
-	req.set('X-Csrf-Token', localStorage['XSRF.Token']);
+	if(req.url[0] === '/') {
+		req.set('X-Csrf-Token', localStorage['XSRF.Token']);
+	}
 	req.set('X-D2L-App-Id', 'deprecated');
 	return req;
 }
@@ -47,16 +49,6 @@ function processRefreshResponse(err, res) {
 }
 
 module.exports = function(req) {
-
-	// This plugin only works for relative URLs. Sending XSRF tokens to foreign
-	// origins would be bad. This plugin is a no-op in those cases.
-	if(req.url[0] != '/') {
-		console.log(
-			'Warning: using superagent-d2l-session-auth for non-relative URLs will ' +
-			'fall back to vanilla superagent. Either use a relative URL (if possible)' +
-			' or don\'t use this plugin for cross-origin requests.');
-		return req;
-	}
 
 	req.use(addHeaders);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-d2l-session-auth",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A superagent plugin that adds D2L auth headers",
   "main": "index.js",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -59,7 +59,6 @@ describe('superagent-auth', function() {
 		var req = request.get('http://localhost/api').use(auth);
 
 		should.not.exist(req.header['X-Csrf-Token']);
-		req.end.should.equal(Object.getPrototypeOf(req).end); // no funny business
 	});
 
 	it('sends refreshcookie preflight on boot', function(done) {


### PR DESCRIPTION
@j3parker: this essentially enables this superagent plugin for non-relative URLs but doesn't send the XSRF token, since it won't be in local storage anyway. This will work now that the token isn't required for cross-origin requests originating from a trusted domain.