### PR TITLE
refact(xsrf) use frau-superagent-xsrf-token. closes #15

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var superagent = require('superagent');
+var superagent = require('superagent'),
+	xsrf = require('frau-superagent-xsrf-token');
 
 var accessTokenExpiresAt = 0,
 	oauth2Enabled = true;
@@ -10,9 +11,7 @@ function now() {
 }
 
 function addHeaders(req) {
-	if(req.url[0] === '/') {
-		req.set('X-Csrf-Token', localStorage['XSRF.Token']);
-	}
+	req = req.use(xsrf);
 	req.set('X-D2L-App-Id', 'deprecated');
 	return req;
 }
@@ -50,7 +49,7 @@ function processRefreshResponse(err, res) {
 
 module.exports = function(req) {
 
-	req.use(addHeaders);
+	req = req.use(addHeaders);
 
 	if(!isOAuth2Enabled()) {
 		return req;

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "pretest": "jshint index.js test",
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha test/*.js -- -R spec",
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+  },
+  "dependencies": {
+    "frau-superagent-xsrf-token": "^1.0.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,9 +4,6 @@ var nock = require('nock'),
 
 nock.disableNetConnect();
 
-var XSRF_TOKEN = 'some-token';
-global.localStorage = { 'XSRF.Token': XSRF_TOKEN };
-
 var auth = require('../');
 
 function now() {
@@ -23,7 +20,7 @@ describe('superagent-auth', function() {
 		auth._setAccessTokenExpiry(0);
 	});
 
-	it('adds app id (legacy)', function() {
+	it('adds app id (legacy)', function(done) {
 		auth._setAccessTokenExpiry(theFuture());
 
 		var endpoint = nock('http://localhost')
@@ -34,40 +31,17 @@ describe('superagent-auth', function() {
 		request
 			.get('/api')
 			.use(auth)
-			.end(function() {});
-
-		endpoint.done();
-	});
-
-	it('adds csrf token for relative URLs', function() {
-		auth._setAccessTokenExpiry(theFuture());
-
-		var endpoint = nock('http://localhost')
-			.matchHeader('X-Csrf-Token', XSRF_TOKEN)
-			.get('/api')
-			.reply(200);
-
-		request
-			.get('/api')
-			.use(auth)
-			.end(function() {});
-
-		endpoint.done();
-	});
-
-	it('does not add xsrf token for non-relative URLs', function() {
-		var req = request.get('http://localhost/api').use(auth);
-
-		should.not.exist(req.header['X-Csrf-Token']);
+			.end(function() {
+				endpoint.done();
+				done();
+			});
 	});
 
 	it('sends refreshcookie preflight on boot', function(done) {
 		var endpoint = nock('http://localhost')
 			.post('/d2l/lp/auth/oauth2/refreshcookie')
-			.matchHeader('X-Csrf-Token', XSRF_TOKEN)
 			.reply(204)
 			.get('/api')
-			.matchHeader('X-Csrf-Token', XSRF_TOKEN)
 			.reply(200);
 
 		request


### PR DESCRIPTION
I removed tests specific to xsrf tokens. Could be good to still have them, but the logic of what that means is contained within the dep.

R= @dlockhart, @j3parker 