### PR TITLE
Workaround an issue with frame detection when Brightspace Polymer com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ request
     });
 ```
 
+For strictly iframed applications, consider requiring `superagent-d2l-session-auth/framed` instead.
+
+
 
 ### API
 

--- a/framed.js
+++ b/framed.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getJwt = require('frau-jwt'),
+var getJwt = require('frau-jwt/framed'),
 	auth = require('./superagent-d2l-session-auth');
 
 module.exports = function(opts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-d2l-session-auth",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A superagent plugin that adds D2L auth headers",
   "main": "index.js",
   "repository": {
@@ -38,7 +38,7 @@
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "frau-jwt": "^1.0.8",
+    "frau-jwt": "^1.1.0",
     "frau-superagent-xsrf-token": "^1.0.1"
   }
 }

--- a/superagent-d2l-session-auth.js
+++ b/superagent-d2l-session-auth.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var url = require('url'),
+	xsrf = require('frau-superagent-xsrf-token');
+
+function noop() {}
+
+function isRelative/*ly safe*/(url) {
+	return url.hostname === null;
+}
+
+function endsWith(haystack, needle) {
+	var expectedPosition = haystack.length - needle.length;
+	var lastIndex = haystack.indexOf(needle, expectedPosition);
+	var result = lastIndex !== -1 && lastIndex === expectedPosition;
+	return result;
+}
+
+function isBrightspaceApi(url) {
+	return url.protocol === 'https:'
+		&& (url.hostname === 'api.brightspace.com'
+			|| endsWith(url.hostname, '.api.brightspace.com')
+		);
+}
+
+function isTrustedHost(url, trustedHost) {
+	return typeof trustedHost === 'string'
+		&& url.host === trustedHost.toLowerCase();
+}
+
+function isTrusted(parsed, trustedHost) {
+	return isBrightspaceApi(parsed)
+		|| isTrustedHost(parsed, trustedHost);
+}
+
+module.exports = function(getJwt, opts) {
+	opts = opts || {};
+
+	return function(req) {
+		req = req.use(xsrf);
+
+		var end = req.end;
+		req.end = function(cb) {
+			function finish() {
+				req.end = end;
+				req.end(cb);
+			}
+
+			var parsed = url.parse(req.url);
+
+			if (isRelative(parsed) || !isTrusted(parsed, opts.trustedHost)) {
+				finish();
+				return this;
+			}
+
+			getJwt(opts.scope)
+				.then(function(token) {
+					req.set('Authorization', 'Bearer ' + token);
+				})
+				.catch(noop)
+				.then(function() {
+					// Run this async in another turn
+					// So we don't catch errors with our Promise
+					setTimeout(finish);
+				});
+
+			return this;
+		};
+
+		return req;
+	};
+};

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,8 @@ var assert = require('assert'),
 
 nock.disableNetConnect();
 
-var auth = rewire('../');
+var auth = rewire('../'),
+	framed = rewire('../framed');
 
 describe('superagent-auth', function() {
 	var getJwt;
@@ -141,6 +142,24 @@ describe('superagent-auth', function() {
 			.end(function() {});
 
 		should.exist(req);
+	});
+
+	describe('framed', function() {
+		var sessionAuth;
+		beforeEach(function() {
+			framed.__set__('getJwt', getJwt);
+			sessionAuth = sinon.spy(framed.__get__('auth'));
+			framed.__set__('auth', sessionAuth);
+		});
+
+		it('should call sessionAuth with getJwt', function() {
+			request
+				.get('http://localhost/api')
+				.use(framed())
+				.end(function() {});
+
+			sinon.assert.calledWith(sessionAuth, getJwt, undefined);
+		});
 	});
 
 });


### PR DESCRIPTION
Workaround an issue with frame detection when Brightspace Polymer components are included (due to window.D2L being defined.)

Allows a free-range application to force framed auth.

Instead of: `require('superagent-d2l-session-auth');`
Use: `require('superagent-d2l-session-auth/framed');`