### PR TITLE
GAUD-9543: upgrade frau-jwt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "frau-jwt": "^2.0.0",
+        "frau-jwt": "^2.4.0",
         "frau-superagent-xsrf-token": "^2.0.0"
       },
       "devDependencies": {
@@ -1285,19 +1285,12 @@
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
-    "node_modules/frau-framed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/frau-framed/-/frau-framed-1.2.0.tgz",
-      "integrity": "sha512-ipVZVKgsacvRAteoozROq4BmFBu39lIXXlZIeNjOsBnTnelA3Sz1MVRpvpGe5CK6vjETRy1yPKQx50yvnf47GQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/frau-jwt": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/frau-jwt/-/frau-jwt-2.3.0.tgz",
-      "integrity": "sha512-UA3122CIl3CYDJ5Q7PUbYlbnnxb8JxQb2nrLkFnHJ7VXm9HYcniJi3x8SIvxG2fkM/NjdvFHyW+NtzsMjEtfqg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/frau-jwt/-/frau-jwt-2.4.0.tgz",
+      "integrity": "sha512-u/TTqANCbDBtCqCJVWWtF86ihvGr9HoH29OiDBvr17UpGmP4n1RBulprL5QJjMC2ZPHP/qIqr4NVCuHpIplIvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "frau-framed": "^1.0.1",
         "frau-superagent-xsrf-token": "^2.0.0",
         "ifrau": "^0.39.0",
         "superagent": "^7"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "frau-jwt": "^2.0.0",
+    "frau-jwt": "^2.4.0",
     "frau-superagent-xsrf-token": "^2.0.0"
   }
 }


### PR DESCRIPTION
Picking up a very targeted change as `frau-framed` has been EOL'd and rolled directly into `frau-jwt`. No functional change here, just the merging of two packages.

`frau-framed` will be graveyarded and removed from npm shortly.